### PR TITLE
[fix] (client.invite) discordapp.com => discord.com

### DIFF
--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -343,7 +343,7 @@ class KlasaClient extends Discord.Client {
 	 */
 	get invite() {
 		const permissions = new Permissions(this.constructor.basePermissions).add(...this.commands.map(command => command.requiredPermissions)).bitfield;
-		return `https://discordapp.com/oauth2/authorize?client_id=${this.application.id}&permissions=${permissions}&scope=bot`;
+		return `https://discord.com/oauth2/authorize?client_id=${this.application.id}&permissions=${permissions}&scope=bot`;
 	}
 
 	/**


### PR DESCRIPTION
### Description of the PR


### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- migrate invite link from discordapp.com to discord.com

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
